### PR TITLE
DataBase design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
 * Ruby version
 
 * System dependencies

--- a/README.md
+++ b/README.md
@@ -29,14 +29,16 @@
 ### Association
 - has_many :groups
 - has_many :messages
+- has_many :members
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|text|null: false, add_index|
+|name|text|null: false, add_index|
 ### Assotiation
 - has_many :users
 - has_many :messages
+- has_many :members
 
 ## messagesテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # README
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-
-* Database creation
-
 ## membersテーブル
 
 |Column|Type|Options|
@@ -23,22 +14,20 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false, add_index, unique|
-|email|text|null: false, add_index, unique|
+|name|string|null: false, add_index, unique: true|
+|email|text|null: false, add_index, unique: true|
 |password|text|null: false|
 ### Association
-- has_many :groups
+- has_many :groups, through: :members
 - has_many :messages
-- has_many :members
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|text|null: false, add_index|
 ### Assotiation
-- has_many :users
+- has_many :users, thorough: :members
 - has_many :messages
-- has_many :members
 
 ## messagesテーブル
 |Column|Type|Options|
@@ -50,14 +39,3 @@
 ### Association
 - belongs_to :user
 - belongs_to :group
-
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false, add_index|
-|email|text|null: false, add_index|
+|name|string|null: false, add_index, unique|
+|email|text|null: false, add_index, unique|
 |password|text|null: false|
 ### Association
 - has_many :groups

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Things you may want to cover:
 * Configuration
 
 * Database creation
+
 ## membersテーブル
 
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -24,6 +24,36 @@ Things you may want to cover:
 - belongs_to :group
 - belongs_to :user
 
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false, add_index|
+|email|text|null: false, add_index|
+|password|text|null: false|
+### Association
+- has_many :groups
+- has_many :messages
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|text|null: false, add_index|
+### Assotiation
+- has_many :users
+- has_many :messages
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|
+|image|text|
+|user_id|integer|foreign_key: true|
+|group_id|integer|foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
 * Database initialization
 
 * How to run the test suite

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false, add_index, unique: true|
-|email|text|null: false, add_index, unique: true|
+|email|text|null: false, unique: true|
 |password|text|null: false|
 
 ### Association
+- has_many :members
 - has_many :groups, through: :members
 - has_many :messages
-- has_many :members
 
 ## groupsテーブル
 |Column|Type|Options|
@@ -28,9 +28,9 @@
 |name|text|null: false, add_index|
 
 ### Assotiation
+- has_many :members
 - has_many :users, through: :members
 - has_many :messages
-- has_many :members
 
 ## messagesテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Things you may want to cover:
 
 * Configuration
 
+
 * Database creation
 
 ## membersテーブル

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # README
 
 ## membersテーブル
-
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
@@ -17,17 +16,21 @@
 |name|string|null: false, add_index, unique: true|
 |email|text|null: false, add_index, unique: true|
 |password|text|null: false|
+
 ### Association
 - has_many :groups, through: :members
 - has_many :messages
+- has_many :members
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|text|null: false, add_index|
+
 ### Assotiation
-- has_many :users, thorough: :members
+- has_many :users, through: :members
 - has_many :messages
+- has_many :members
 
 ## messagesテーブル
 |Column|Type|Options|
@@ -36,6 +39,7 @@
 |image|text|
 |user_id|integer|foreign_key: true|
 |group_id|integer|foreign_key: true|
+
 ### Association
 - belongs_to :user
 - belongs_to :group


### PR DESCRIPTION
# What
・usersテーブルとgroupsテーブルのアソシエーションの順番をかえました。
・usersテーブル、カラムemailのadd_indexオブションを削除しました。
# Why
・プログラムは上から読まれていくため、定義されていないmembersに対してthroughができないため。
・emailの検索の高速化は不要であったため。